### PR TITLE
fix(admin): Remove non-existent local script from CMS loader

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -27,7 +27,6 @@
     // Resilient loader: try multiple CDNs/versions until one succeeds
     (function () {
       const sources = [
-        '/admin/decap-cms.js?v=20250810-csp7',
         'https://unpkg.com/decap-cms@^3/dist/decap-cms.js',
         'https://cdn.jsdelivr.net/npm/decap-cms@3/dist/decap-cms.js',
         'https://unpkg.com/decap-cms@^2/dist/decap-cms.js',


### PR DESCRIPTION
This commit removes the attempt to load `/admin/decap-cms.js` from the resilient loader in `admin/index.html`.

This local file does not exist in the repository. A redirect rule on Netlify was causing this request to incorrectly return the `index.html` file itself, which resulted in a `SyntaxError: Unexpected token '<'` when the browser tried to parse the HTML as JavaScript. This error prevented the CMS from loading.

By removing this incorrect path, the loader will now correctly fall back to the public CDN URLs for Decap CMS, resolving the script loading failure.